### PR TITLE
fix: Fixed a misspelling in registry editor invocation

### DIFF
--- a/jb-reset-trial.ps1
+++ b/jb-reset-trial.ps1
@@ -70,7 +70,7 @@ $promptQueue = New-Object System.Collections.Generic.List[System.Object];
 
 foreach($path in $regDelete.Keys){
     if ($null -eq $regDelete[$path] -or ($regDelete[$path].Count -eq 0)) {
-        $promptQueue.Add("EG RDELETE `"$path`" /f")
+        $promptQueue.Add("REG RDELETE `"$path`" /f")
     }
     else {
         foreach ($entry in $regDelete[$path]) {

--- a/jb-reset-trial.ps1
+++ b/jb-reset-trial.ps1
@@ -70,7 +70,7 @@ $promptQueue = New-Object System.Collections.Generic.List[System.Object];
 
 foreach($path in $regDelete.Keys){
     if ($null -eq $regDelete[$path] -or ($regDelete[$path].Count -eq 0)) {
-        $promptQueue.Add("REG RDELETE `"$path`" /f")
+        $promptQueue.Add("REG DELETE `"$path`" /f")
     }
     else {
         foreach ($entry in $regDelete[$path]) {


### PR DESCRIPTION
It appear that there is a misspell in registry edit invocation("EG", instead of "REG"). Fixed it